### PR TITLE
Fix invalid string literals

### DIFF
--- a/cms_server/public/content/dart/1_control_flow/switch_and_case.md
+++ b/cms_server/public/content/dart/1_control_flow/switch_and_case.md
@@ -114,14 +114,14 @@ Finally, you can use a `continue` statement and a label if you want to fall thro
 String animal = 'tiger';
 switch(animal) {
   case 'tiger':
-    print('it's a tiger');
+    print("it's a tiger");
     continue alsoCat;
   case 'lion':
-    print('it's a lion');
+    print("it's a lion");
     continue alsoCat;
   alsoCat:
   case 'cat':
-    print('it's a cat');
+    print("it's a cat");
     break;
   // ...
 }


### PR DESCRIPTION
To use `'` inside a string, change surrounding quotation marks to `"`
We can use `\'` instead.